### PR TITLE
Add as default the most basic check of all; ping

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -121,7 +121,7 @@ when 'rhel', 'fedora'
     },
     'nagios-plugins-users' => {
       'version' => nil
-    }
+    },
     'nagios-plugins-ping' => {
       'version' => nil
     }
@@ -142,6 +142,9 @@ when 'freebsd'
   default['nrpe']['pid_file']          = '/var/run/nrpe2/nrpe2.pid'
   default['nrpe']['packages']          = {
     'nrpe' => {
+      'version' => nil
+    },
+    'nagios-plugins-ping' => {
       'version' => nil
     }
   }

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -122,6 +122,9 @@ when 'rhel', 'fedora'
     'nagios-plugins-users' => {
       'version' => nil
     }
+    'nagios-plugins-ping' => {
+      'version' => nil
+    }
   }
   if node['kernel']['machine'] == 'i686'
     default['nrpe']['home']            = '/usr/lib/nagios'


### PR DESCRIPTION
When using the nagios cookbook and including the nrpe cookbook with only default, this change will enable Nagios to get, by default install,  "green" hosts.