### PR TITLE
always include newline in resource files

### DIFF
--- a/providers/check.rb
+++ b/providers/check.rb
@@ -45,6 +45,8 @@ action :add do
     file_contents += " -w #{new_resource.warning_condition}" unless new_resource.warning_condition.nil?
     file_contents += " -c #{new_resource.critical_condition}" unless new_resource.critical_condition.nil?
     file_contents += " #{new_resource.parameters}" unless new_resource.parameters.nil?
+    file_contents += "\n"
+
     f = file config_file do
       owner 'root'
       group node['nrpe']['group']


### PR DESCRIPTION
it looks better this way when looking the files from terminal using cat

some parsers even may break without newlines (shell scripts for example!)