### PR TITLE
add LSB header to init script

### DIFF
--- a/templates/default/nagios-nrpe-server.erb
+++ b/templates/default/nagios-nrpe-server.erb
@@ -8,6 +8,18 @@
 # processname: <%= node['nrpe']['service_name'] %>
 # config: <%= node['nrpe']['conf_dir'] %>/nrpe.cfg
 
+### BEGIN INIT INFO
+# Provides:          nagios-nrpe-server
+# Required-Start:    $local_fs $remote_fs $syslog $named $network $time
+# Required-Stop:     $local_fs $remote_fs $syslog $named $network
+# Should-Start:      
+# Should-Stop:       
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: nagios remote plugin executor
+# Description:       nagios-nrpe is a daemon for running checks on remote systems.
+### END INIT INFO
+
 <% if ['rhel', 'fedora'].include?(node['platform_family']) -%>
 # Source function library
 if [ -f /etc/rc.d/init.d/functions ]; then

--- a/templates/default/nagios-nrpe-server.erb
+++ b/templates/default/nagios-nrpe-server.erb
@@ -9,7 +9,7 @@
 # config: <%= node['nrpe']['conf_dir'] %>/nrpe.cfg
 
 ### BEGIN INIT INFO
-# Provides:          nagios-nrpe-server
+# Provides:          <%= node['nrpe']['service_name'] %>
 # Required-Start:    $local_fs $remote_fs $syslog $named $network $time
 # Required-Stop:     $local_fs $remote_fs $syslog $named $network
 # Should-Start:      


### PR DESCRIPTION
I was having this problem on my Ubuntu 14.10 install when the cookbook tries to add nagios-nrpe-server to the default runlevels.

```
# /usr/sbin/update-rc.d nagios-nrpe-server defaults
insserv: warning: script 'nagios-nrpe-server' missing LSB tags and overrides
insserv: There is a loop between service monit and nagios-nrpe-server if stopped
insserv:  loop involving service nagios-nrpe-server at depth 2
insserv:  loop involving service monit at depth 1
insserv: Stopping nagios-nrpe-server depends on monit and therefore on system facility `$all' which can not be true!
insserv: exiting now without changing boot order!
update-rc.d: error: insserv rejected the script header
```

Adding the header fixed the problem.