### PR TITLE
add template support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   Exclude:
-    - vendor/**
+    - vendor/**/*
 
 AlignParameters:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The check LWRP provides an easy way to add and remove NRPE checks from within co
 - `critical_condition` String that you will pass to the command with the -c flag
 - `command` The actual command to execute (including the path). If this is not specified, this will use `#{node['nrpe']['plugin_dir']}/command_name` as the path to the command.
 - `parameters` Any additional parameters you wish to pass to the plugin.
+- `template` Use the specific erb template to render NRPE config command.
 
 #### Examples
 ```ruby
@@ -114,6 +115,13 @@ nrpe_check "check_load" do
 end
 ```
 
+Using template:
+```ruby
+nrpe_check "check_load" do
+  template "check_load.cfg.erb"
+  action :add
+end
+```
 
 License & Authors
 -----------------

--- a/providers/check.rb
+++ b/providers/check.rb
@@ -28,7 +28,7 @@ action :add do
 
   if new_resource.template
     unless new_resource.command.nil?
-      fail 'You cannot specify command and template!'
+      raise 'You cannot specify command and template!'
     end
     f = template config_file do
       owner 'root'

--- a/providers/check.rb
+++ b/providers/check.rb
@@ -27,7 +27,7 @@ action :add do
   config_file = "#{node['nrpe']['conf_dir']}/nrpe.d/#{new_resource.command_name}.cfg"
 
   if new_resource.template
-    if !new_resource.command.nil?
+    unless new_resource.command.nil?
       fail 'You cannot specify command and template!'
     end
     f = template config_file do

--- a/resources/check.rb
+++ b/resources/check.rb
@@ -33,3 +33,4 @@ attribute :warning_condition, :kind_of => [Integer, String], :default => nil
 attribute :critical_condition, :kind_of => [Integer, String], :default => nil
 attribute :command, :kind_of => String
 attribute :parameters, :kind_of => String, :default => nil
+attribute :template, kind_of: String, default: nil


### PR DESCRIPTION
this adds support for template in LWRP, similar to [sudo](https://github.com/chef-cookbooks/sudo) cookbook:

```ruby
nrpe_check 'nf_conntrack_max' do
    template 'nf_conntrack_max.cfg.erb'
    action :add
end
```

this can be used if one wishes to have complex definition or just wishing to have multiple commands defined in same nrpe config file fragment.