### PR TITLE
ensure that systemd unit file matches the nrpe user attribute

### DIFF
--- a/templates/default/nrpe.service.erb
+++ b/templates/default/nrpe.service.erb
@@ -1,0 +1,15 @@
+[Unit]
+Description=NRPE
+After=network.target
+Requires=network.target
+
+[Service]
+Type=forking
+User=<%= @nrpe['user'] %>
+Group=<%= @nrpe['group'] %>
+EnvironmentFile=/etc/sysconfig/nrpe
+ExecStart=/usr/sbin/nrpe -c /etc/nagios/nrpe.cfg -d $NRPE_SSL_OPT
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This fixes centos7 usage with non-default nrpe user attributes.