### PR TITLE
Only restart NRPE at the end of the chef-run

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'tsmith84@gmail.com'
 license           'Apache 2.0'
 description       'Installs and configures Nagios NRPE client'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '1.6.3'
+version           '1.6.4'
 issues_url       'https://github.com/schubergphilis/nrpe/issues' if respond_to?(:issues_url)
 source_url       'https://github.com/schubergphilis/nrpe' if respond_to?(:source_url)
 chef_version     '>= 11.0' if respond_to?(:chef_version)

--- a/providers/check.rb
+++ b/providers/check.rb
@@ -46,7 +46,7 @@ action :add do
       group node['nrpe']['group']
       mode '0640'
       source new_resource.template
-      notifies node['nrpe']['check_action'], "service[#{node['nrpe']['service_name']}]"
+      notifies node['nrpe']['check_action'], "service[#{node['nrpe']['service_name']}]", :delayed
     end
   else
     command = new_resource.command || "#{node['nrpe']['plugin_dir']}/#{new_resource.command_name}"
@@ -61,7 +61,7 @@ action :add do
       group node['nrpe']['group']
       mode '0640'
       content file_contents
-      notifies node['nrpe']['check_action'], "service[#{node['nrpe']['service_name']}]"
+      notifies node['nrpe']['check_action'], "service[#{node['nrpe']['service_name']}]", :delayed
     end
   end
   new_resource.updated_by_last_action(f.updated_by_last_action?)
@@ -83,7 +83,7 @@ action :remove do
     Chef::Log.info "Removing #{new_resource.command_name} from #{node['nrpe']['conf_dir']}/nrpe.d/"
     f = file config_file do
       action :delete
-      notifies node['nrpe']['check_action'], "service[#{node['nrpe']['service_name']}]"
+      notifies node['nrpe']['check_action'], "service[#{node['nrpe']['service_name']}]", :delayed
     end
     new_resource.updated_by_last_action(f.updated_by_last_action?)
   end

--- a/recipes/_source_nrpe.rb
+++ b/recipes/_source_nrpe.rb
@@ -37,7 +37,7 @@ if node['init_package'] == 'systemd'
   template "#{node['nrpe']['systemd_unit_dir']}/nrpe.service" do
     source 'nrpe.service.erb'
     notifies :run, 'execute[nrpe-reload-systemd]', :immediately
-    notifies :restart, 'service[nrpe]'
+    notifies :restart, 'service[nrpe]', :delayed
     variables(
       nrpe: node['nrpe']
     )

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -61,7 +61,7 @@ template "#{node['nrpe']['conf_dir']}/nrpe.cfg" do
     mon_host: mon_host.uniq.sort,
     nrpe_directory: include_dir
   )
-  notifies :restart, "service[#{node['nrpe']['service_name']}]"
+  notifies :restart, "service[#{node['nrpe']['service_name']}]", :delayed
 end
 
 execute 'nrpe-reload-systemd' do
@@ -73,7 +73,7 @@ end
 template "#{node['nrpe']['systemd_unit_dir']}/nrpe.service" do
   source 'nrpe.service.erb'
   notifies :run, 'execute[nrpe-reload-systemd]', :immediately
-  notifies :restart, "service[#{node['nrpe']['service_name']}]"
+  notifies :restart, "service[#{node['nrpe']['service_name']}]", :delayed
   only_if  { ::File.exist?("#{node['nrpe']['systemd_unit_dir']}/nrpe.service") }
   only_if  { node['init_package'] == 'systemd' }
   variables(


### PR DESCRIPTION
On systems that have systemd, the rate limiting will kick in and mark the nrpe service as failed if a lot of checks are changed. This causes the chef-run to fail.

Also, it makes sense to only restart NRPE once at the end of the run when all the files are in place.